### PR TITLE
Proposal: Construct, Sign, and Update APIs for issuance and revocation of credentials

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1,99 +1,62 @@
 openapi: 3.0.0
-# Added by API Auto Mocking Plugin
-servers:
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/danubetech/credential-issuer/0.0.1
 info:
-  description: This is an open API specification for issuing digital credentials based on standards such as the Verifiable Credentials Data Model (https://www.w3.org/TR/vc-data-model/), JWT (https://tools.ietf.org/html/rfc7519), and Open Badges (https://openbadges.org/). Implementations of this API may differ in terms of which data formats or proof formats they do or do not support. Also, implementations may choose to not support certain parts of this API (e.g. optional parts include changing and retrieving the status of a credential, or refreshing a credential).
-  version: "0.0.1"
-  title: Credential Issuer API
+  description: This is an open HTTP API specification for issuing Verifiable Credentials based on the W3C Verifiable Credentials Data Model (https://www.w3.org/TR/vc-data-model/). Implementations of this API may differ in terms of which representation formats or proof formats they do or do not support.
+  version: "0.0.2"
+  title: Verifiable Credential Issuer HTTP API
   contact:
-    email: markus@danubetech.com
+    email: george.aristy@securekey.com
   license:
     name: All documents in this Repository are licensed by contributors under the [W3C Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).
-tags:
-  - name: internal
-    description: Internal APIs facing the Issuer.
-  - name: public
-    description: Public APIs facing the Holder and Verifier.
 paths:
-  /credential:
+  /credentials/sign:
     post:
-      tags:
-        - internal
-      summary: Issues a credential and returns it in the response body.
-      operationId: issueCredential
-      description: Issues a credential and returns it in the response body. Support of this part of the API is REQUIRED for implementations.
-      parameters:
-        - in: query
-          required: false
-          name: templateReference
-          schema:
-            type: string
-          description: Optional internal reference to a credential template. If this is present, it may be used to automatically pre-populate certain fields in the request body.
-          example: 67466513-67a0-4812-8f26-995dd78c5aa6
-        - in: query
-          required: false
-          name: subjectReference
-          schema:
-            type: string
-          description: Optional internal reference to the subject for which to issue a credential. If this is present, it may be used to pre-populate certain fields in the request body (e.g. "claims" and/or "subject").
-          example: 73b32334-81f3-4f4c-911e-710c7aadd4d8
+      summary: Constructs a credential from a template, attaches proof, and returns it in the response body.
+      operationId: signCredential
+      description: Signs a credential and returns it in the response body. Support of this part of the API is REQUIRED for implementations.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IssueRequest'
-        description: Parameters for issuing the credential.
+              $ref: '#/components/schemas/SignCredentialRequest'
+        description: Parameters for constructing and issuing the credential.
       responses:
         '201':
-          description: credential successfully issued!
+          description: Credential was successfully issued.
           content:
             application/json:
               schema:
-                type: object
-                description: The issued credential. This SHOULD include a reference or ID that can be used later for other parts of the API, e.g. changing and retrieving the status of the credential, or refreshing the credential.
+                $ref: '#/components/schemas/CredentialResponse'
         '400':
-          description: invalid input!
+          description: Malformed request from client.
         '500':
-          description: error!
-  /credential/{credentialReference}:
-    get:
-      tags:
-        - internal
-      summary: Retrieves a credential that has already been issued, and returns it in the response body.
-      operationId: retrieveCredential
-      description: Retrieves a credential that has already been issued, and returns it in the response body. The retrieved credential MUST be identical to the original credential when it was first issued. This can not be used for refreshing an expired credential. Support of this part of the API is OPTIONAL for implementations.
-      parameters:
-        - in: path
-          required: true
-          name: credentialReference
-          schema:
-            type: string
-          description: Reference to a credential that has been issued.
-      responses:
-        '200':
-          description: credential successfully retrieved!
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The retrieved credential.
-        '400':
-          description: invalid input!
-        '404':
-          description: credential not found!
-        '500':
-          description: error!
-        '501':
-          description: not supported by this implementation!
-  /credential/{credentialReference}/status:
+          description: Internal error
+  /credentials/construct:
     post:
-      tags:
-        - internal
+      summary: Constructs a credential from pre-configured templates and returns it in the response body.
+      operationId: constructCredential
+      description: Constructs and issues a credential and returns it in the response body. Support of this part of the API is REQUIRED for implementations.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConstructCredentialRequest"
+        description: Parameters for signing and issuing the credential.
+      responses:
+        '201':
+          description: Credential was successfully issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialResponse'
+        '400':
+          description: Malformed request from client.
+        '500':
+          description: Internal error
+  /credentials/{credentialReference}/status:
+    post:
       summary: Changes the credential status.
       operationId: changeCredentialStatus
-      description: Changes the credential status. Support of this part of the API is OPTIONAL for implementations.
+      description: Changes the credential status. Support of this part of the API is REQUIRED for implementations.
       parameters:
         - in: path
           required: true
@@ -118,133 +81,168 @@ paths:
           description: error!
         '501':
           description: not supported by this implementation!
-    get:
-      tags:
-        - public
-      summary: Retrieves the credential status and returns it in the response body.
-      operationId: retrieveCredentialStatus
-      description: Retrieves the credential status and returns it in the response body. Support of this part of the API is OPTIONAL for implementations. WARNING - this type of "phone home" functionality is problematic from a privacy perspective, therefore this is likely to be removed in a future version.
-      parameters:
-        - in: path
-          required: true
-          name: credentialReference
-          schema:
-            type: string
-          description: Reference to a credential that has been issued.
-      responses:
-        '200':
-          description: credential status successfully retrieved!
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The credential status.
-        '400':
-          description: invalid input!
-        '404':
-          description: credential not found!
-        '500':
-          description: error!
-        '501':
-          description: not supported by this implementation!
-  /credential/{credentialReference}/refresh:
-    post:
-      tags:
-        - public
-      summary: Refreshes a credential and returns it in the response body.
-      operationId: refreshCredential
-      description: Refreshes a credential and returns it in the response body. Support of this part of the API is OPTIONAL for all implementations. WARNING - it may not make sense to model this functionality as a public API, instead the processes for "refreshing" may be more complex and use case specific, therefore this is likely to be removed in a future version.
-      parameters:
-        - in: path
-          required: true
-          name: credentialReference
-          schema:
-            type: string
-          description: Reference to a credential that has been issued.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RefreshRequest'
-        description: Parameters for refreshing the credential.
-      responses:
-        '200':
-          description: credential successfully refreshed!
-          content:
-            application/json:
-              schema:
-                type: object
-                description: The refreshed credential.
-        '400':
-          description: invalid input!
-        '404':
-          description: credential not found!
-        '500':
-          description: error!
-        '501':
-          description: not supported by this implementation!
 components:
   schemas:
-    IssueRequest:
+    ConstructCredentialRequest:
       type: object
+      required:
+        - issuer
+        - vcTemplateReference
+        - claims
+        - output
       properties:
         issuer:
           type: string
-          description: Optional identifier for the issuer of the credential. If this is missing, it may be pre-configured or implied by other values in the request.
-          example: did:example:76e12ec712ebc6f1c221ebfeb1f
-        subject:
+          description: A reference to the issuer's pre-configured profile.
+        vcTemplateReference:
           type: string
-          description: Optional identifier for the subject of the credential. If this is missing, it may be pre-configured or implied by other values in the request, or there may not be an identifier for the subject of the credential.
-          example: did:example:ebfeb1f712ebc6f1c276e12ec21
-        types:
-          type: array
-          items:
-            type: string
-          description: Optional value for the type(s) of a credential. If this is missing, it may be pre-configured or implied by other values in the request.
-          example: UniversityDegreeCredential
-        issuanceDate:
-          type: string
-          format: date-time
-          description: Optional value for the issuance date and time of the credential, to be used only when this value should not be automatically set to the current date and time.
-          example: '2010-01-01T19:23:24Z'
-        expirationDate:
-          type: string
-          format: date-time
-          description: Optional value for the expiration date and time of the credential. If this is missing, it may be pre-configured or implied by other values in the request, or the credential may not have an expiration date and time.
-          example: '2011-01-01T19:23:24Z'
+          description: A reference to the pre-configured Verifiable Credential template.
         claims:
-          type: object
-          additionalProperties: true
-          description: Optional object containing claims and their values.
-          example: {"name": "Jayden Doe"}
-        evidence:
-          type: object
-          additionalProperties: true
-          description: Optional object containing evidence of the credential.
-          example: {}
-        termsOfUse:
-          type: object
-          additionalProperties: true
-          description: Optional object containing terms of use of the credential.
-          example: {}
-        credentialFormat:
+          type: array
+          description: A set of claims about one or more subjects.
+          items:
+            $ref: '#/components/schemas/Claims'
+        output:
+          $ref: '#/components/schemas/Output'
+      example: {
+        "issuer": "did:example:123456677",
+        "vcTemplateReference": "https://issuer.oidp.uscis.gov/schemas/v1/prcard",
+        "claims": [{
+          "sub": "did:example:123456abcdefg",
+          "givenName": "JOHN",
+          "familyName": "SMITH",
+          "gender": "Male",
+          "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+          "residentSince": "2015-01-01",
+          "lprCategory": "C09",
+          "lprNumber": "999-999-999",
+          "commuterClassification": "C1",
+          "birthCountry": "Bahamas",
+          "birthDate": "1958-07-17"
+        }],
+        "output": {
+          "encoding": "jsonld",
+          "encodingOptions": {
+            "suite": "JsonWebSignature2020",
+            "alg": "ES256"
+          }
+        }
+      }
+    SignCredentialRequest:
+      type: object
+      required:
+        - issuer
+        - credential
+        - output
+      properties:
+        issuer:
           type: string
-          description: Optional value to specify the credential format. Well-known values are "jsonld", "jwt", "blockcerts". Other values MAY be supported. If this is missing, it may be pre-configured, and a default credential format will be used.
-          example: jsonld
-        proofFormat:
+          description: A reference to the issuer's identifier.
+        credential:
+          type: object
+          description: The credential to be issued minus the proofs
+        output:
+          $ref: '#/components/schemas/Output'
+      example: {
+        "issuer": "did:example:1234567",
+        "credential": {
+          "credential": {
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://w3id.org/citizenship/v1"
+            ],
+            "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+            "type": [
+              "VerifiableCredential",
+              "PermanentResidentCard"
+            ],
+            "issuanceDate": "2019-12-03T12:19:52Z",
+            "expirationDate": "2029-12-03T12:19:52Z",
+            "credentialSubject": {
+              "id": "did:example:b34ca6cd37bbf23",
+              "type": [
+                "PermanentResident",
+                "Person"
+              ],
+              "givenName": "JOHN",
+              "familyName": "SMITH",
+              "gender": "Male",
+              "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+              "residentSince": "2015-01-01",
+              "lprCategory": "C09",
+              "lprNumber": "999-999-999",
+              "commuterClassification": "C1",
+              "birthCountry": "Bahamas",
+              "birthDate": "1958-07-17"
+            }
+          }
+        },
+        "output": {
+          "encoding": "jsonld",
+          "encodingOptions": {
+            "suite": "JsonWebSignature2020",
+            "alg": "ES256"
+          }
+        }
+      }
+    CredentialResponse:
+      type: object
+      properties:
+        credentialReference:
           type: string
-          description: Optional value to specify the proof format. Well-known values are "ld-proof", "jws", "blockcerts". Other values MAY be supported. If this is missing, it may be pre-configured or implied by other values in the request (e.g. "credentialFormat"), and a default proof format will be used.
-          example: jws
-        credentialFormatOptions:
-          type: object
-          additionalProperties: true
-          description: Optional object containing additional options specific to the chosen credential format. E.g. for the "jsonld" credential format, this could contain JSON-LD context(s) to be included in the credential.
-          example: {"@context": "https://www.w3.org/2018/credentials/examples/v1"}
-        proofFormatOptions:
-          type: object
-          additionalProperties: true
-          description: Optional object containing additional options specific to the chosen proof format. E.g. for the "jws" proof format, this could specify a key identifier to be used for the proof.
-          example: {"kid": "did:example:abfe13f712120431c276e12ecab#keys-1"}
+          description: Reference to the issued credential.
+        credential:
+          description: Encoded credential.
+          oneOf:
+            - type: string
+            - type: object
+    Claims:
+      type: object
+      description: A set of claims about a single subject. A claim without properties other than 'sub' MUST be rejected.
+      additionalProperties: true
+      required:
+        - sub
+      properties:
+        sub:
+          type: string
+          description: Subject of these claims.
+          example: did:example:123456abcdefg
+    Output:
+      type: object
+      description: Output encoding options.
+      required:
+        - encoding
+        - encodingOptions
+      properties:
+        encoding:
+          type: string
+          enum:
+            - jsonld
+            - jwt
+        encodingOptions:
+          oneOf:
+            - $ref: '#/components/schemas/JSONLDEncoding'
+            - $ref: '#/components/schemas/JWTEncoding'
+    JSONLDEncoding:
+      type: object
+      description: Verifiable Credential encoded as a JSON-LD object with an embedded proof.
+      additionalProperties: true
+      required:
+        - suite
+      properties:
+        suite:
+          type: string
+          description: Linked Data Cryptographic Suite.
+    JWTEncoding:
+      type: object
+      description: Verifiable Credential encoded as a signed JWT.
+      additionalProperties: true
+      required:
+        - alg
+      properties:
+        alg:
+          type: string
+          description: JWS algorithm.
     ChangeStatusRequest:
       type: object
       required:
@@ -262,12 +260,4 @@ components:
           type: object
           additionalProperties: true
           description: Optional object containing additional options for the new status of the credential.
-          example: {}
-    RefreshRequest:
-      type: object
-      properties:
-        options:
-          type: object
-          additionalProperties: true
-          description: Optional object containing additional options for refreshing the credential.
           example: {}


### PR DESCRIPTION
Draft for an API that:

* constructs and issues credentials from pre-configured templates
* issues credentials from an inlined VC (minus proof) in a request body
* updates the status of credentials

Routes are designed for use by entities belonging to the same institution.

Rendered here: https://app.swaggerhub.com/apis/george.aristy/verifiable-credential_issuer_http_api/0.0.2

Signed-off-by: George Aristy <george.aristy@gmail.com>